### PR TITLE
Add support for use with python-stix < 1.2

### DIFF
--- a/openioc-to-stix.py
+++ b/openioc-to-stix.py
@@ -14,6 +14,7 @@ from stix import utils
 
 # Internal
 from openioc2stix import translate
+from openioc2stix.utils import silence_warnings
 from openioc2stix.version import __version__
 
 
@@ -53,7 +54,7 @@ def get_arg_parser():
     return parser
 
 
-@utils.silence_warnings
+@silence_warnings
 def write_package(package, outfn):
     with open(outfn, "w") as f:
         xml = package.to_xml()

--- a/openioc2stix/objectify.py
+++ b/openioc2stix/objectify.py
@@ -133,7 +133,7 @@ def create_dns_obj(search_string, content_string, condition):
 
     entry = DNSCacheEntry()
     entry.dns_entry = record
-    cache.dns_cache_entry = entry
+    cache.dns_cache_entry.append(entry)
 
     return Object(cache)
 

--- a/openioc2stix/objectify.py
+++ b/openioc2stix/objectify.py
@@ -81,6 +81,7 @@ def has_content(object):
 ## primary object functions
 
 def create_disk_obj(search_string, content_string, condition):
+
     from cybox.objects.disk_object import Disk, DiskPartition, PartitionList
 
     disk = Disk()
@@ -106,6 +107,7 @@ def create_disk_obj(search_string, content_string, condition):
     else:
         return None
 
+    disk.type_ = disk.type  # JSA: Hack for old libraries.
     return Object(disk)
 
 def create_dns_obj(search_string, content_string, condition):
@@ -277,7 +279,12 @@ def create_win_event_log_obj(search_string, content_string, condition):
     }
 
     if search_string in attrmap:
-        set_field(eventlog, attrmap[search_string], content_string, condition)
+        try:
+            set_field(eventlog, attrmap[search_string], content_string, condition)
+        except AttributeError:
+            # JSA : Hack for older libraries.
+            if attrmap[search_string] == 'type_':
+                eventlog.type_ = content_string
     elif search_string == "EventLogItem/unformattedMessage/string":
         s = String(xml.sanitize(content_string))
         s.condition = condition
@@ -285,6 +292,8 @@ def create_win_event_log_obj(search_string, content_string, condition):
     else:
         return None
 
+    # JSA: Hack for older libraries.
+    eventlog.type_ = eventlog.type
     return Object(eventlog)
 
 def create_file_obj(search_string, content_string, condition):

--- a/openioc2stix/objectify.py
+++ b/openioc2stix/objectify.py
@@ -133,7 +133,7 @@ def create_dns_obj(search_string, content_string, condition):
 
     entry = DNSCacheEntry()
     entry.dns_entry = record
-    cache.dns_cache_entry.append(entry)
+    cache.dns_cache_entry = [entry]
 
     return Object(cache)
 

--- a/openioc2stix/translate.py
+++ b/openioc2stix/translate.py
@@ -4,14 +4,12 @@
 Internal module dedicated to translating observables and indicators
 as well as translating OpenIOC to CybOX and STIX.
 """
-
 import logging
 
 import cybox.utils
 from cybox.core import Observables, Observable, ObservableComposition
 from cybox.common import ToolInformationList, ToolInformation
 
-import stix.utils
 from stix.core import STIXPackage, STIXHeader
 from stix.common import InformationSource
 from stix.common.vocabs import PackageIntent
@@ -22,7 +20,7 @@ from . import objectify
 from . import xml
 from . import utils
 from . import version
-
+from .utils import silence_warnings
 
 # ID format for translated OpenIOC items
 OPENIOC_ID_FMT = "openioc:item-%s"
@@ -220,7 +218,7 @@ def to_cybox(infile):
     return obsdoc
 
 
-@stix.utils.silence_warnings
+@silence_warnings
 def to_stix(infile):
     """Converts the `infile` OpenIOC xml document into a STIX Package.
 

--- a/openioc2stix/utils.py
+++ b/openioc2stix/utils.py
@@ -67,3 +67,27 @@ def is_empty_observable(o):
         return False
 
     return True
+
+
+try:
+    # For python-stix >= 1.2:
+    from stix.utils import silence_warnings
+except ImportError:
+    # Define it here for python-stix libraries < 1.2
+    import functools
+    import warnings
+
+    def silence_warnings(func):
+        """Function decorator that silences/ignores all Python warnings in the
+        wrapped function.
+        Example:
+            >>> @silence_warnings
+            >>> def foo():
+            >>>     warnings.warn("this will not appear")
+        """
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter('always')
+                return func(*args, **kwargs)
+        return inner


### PR DESCRIPTION
@bworrell , this enables use of the openioc-to-stix library with python-stix libraries that are prior to 1.2.

In particular, Soltra Edge has yet to upgrade to STIX 1.2, and I'd like to use this library in combination with Edge. This enables that use case.

Thanks for considering this commit!